### PR TITLE
Change events

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](http://img.shields.io/travis/open-company/open-company-change.svg?style=flat)](https://travis-ci.org/open-company/open-company-change)
-[![Dependency Status](https://www.versioneye.com/user/projects/59d636ec368b0865338c5466/badge.svg?style=flat)](https://www.versioneye.com/user/projects/59d636ec368b0865338c5466)
-[![Roadmap on Trello](http://img.shields.io/badge/roadmap-trello-blue.svg?style=flat)](https://trello.com/b/3naVWHgZ/open-company-development)
-
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![MPL License](http://img.shields.io/badge/license-MPL-blue.svg?style=flat)](https://www.mozilla.org/MPL/2.0/)
 [![Build Status](http://img.shields.io/travis/open-company/open-company-change.svg?style=flat)](https://travis-ci.org/open-company/open-company-change)
 
+
 ## Background
 
 > There's no going back, and there's no hiding the information. So let everyone have it.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ consumers of this service can ignore events from specific users (such as from th
   "created-at": ISO8601,
   "container-id": 4hex-4hex-4hex UUID,
   "content-id": 4hex-4hex-4hex UUID,
+  "content-type": "board/entry",
   "user-id": 4hex-4hex-4hex UUID
 }
 ```

--- a/project.clj
+++ b/project.clj
@@ -14,16 +14,16 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta3"]
+    [org.clojure/clojure "1.9.0-beta4"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"] 
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.6.2"]
+    [ring/ring-devel "1.6.3"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.6.2" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.6.3" :exclusions [clj-time joda-time commons-codec]]
     ;; CORS library https://github.com/jumblerg/ring.middleware.cors
     [jumblerg/ring.middleware.cors "1.0.1"]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta2"]
+    [org.clojure/clojure "1.9.0-beta3"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.3.5"] 
     ;; Web application library https://github.com/ring-clojure/ring

--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,7 @@
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.5"]
+        [jonase/eastwood "0.2.6-beta2"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit        
         [lein-kibit "0.1.6-beta2" :exclusions [org.clojure/clojure]]
       ]
@@ -113,7 +113,7 @@
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-pprint "1.1.2"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
-        [lein-ancient "0.6.12"]
+        [lein-ancient "0.6.14"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni


### PR DESCRIPTION
https://trello.com/c/Um6p3FXO

This PR supports [https://github.com/open-company/open-company-web/pull/270](https://github.com/open-company/open-company-web/pull/270).

This updates the SQS triggers sent to change service to have 3 event types: `add`, `refresh`, and `delete` and 2 content types: `board` and `entry` to account for the 6 changes we need to report to the UI:

- board add
- board update
- board delete
- entry add
- entry update
- entry delete

Very small change here, just opening up the kind of changes this service can receive from SQS. They are all still reported to the UI as a container change (the container is now an org or a board).

- [x] Review the code
- [x] Follow testing steps in [https://github.com/open-company/open-company-web/pull/270](https://github.com/open-company/open-company-web/pull/270)
- [x] Merge
- [x] Your shoe is untied