### PR TITLE
Update core.async producer/consumer pattern usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,11 @@
 
 > -- Andrew Kantor
 
-Companies struggle to keep everyone on the same page. People are hyper-connected in the moment but still don't know what's happening across the company. Employees and investors, co-founders and execs, customers and community, they all want more transparency. The solution is surprisingly simple and effective - great company updates that build transparency and alignment.
+Companies struggle to keep everyone on the same page. People are hyper-connected in the moment with chat apps, but as teams grow chat gets noisy and people miss key information. Chat might be ideal for spontaneous conversations, but it’s terrible for the more substantial discussions that aren’t meant to be urgent. The solution - **focused conversations that build transparency and alignment**.
 
-With that in mind we designed the [Carrot](https://carrot.io/) software-as-a-service application, powered by the open source [OpenCompany platform](https://github.com/open-company). The product design is based on three principles:
+OpenCompany is the open source platform that powers [Carrot](https://carrot.io), a SaaS app for building transparency and alignment. With Carrot, important company updates, announcements, stories, and strategic plans create focused, topic-based conversations that keep everyone aligned without interruptions.
 
-1. It has to be easy or no one will play.
-2. The "big picture" should always be visible.
-3. Alignment is valuable beyond the team, too.
-
-Carrot simplifies how key business information is shared with stakeholders to create alignment. When information about growth, finances, ownership and challenges is shared transparently, it inspires trust, new ideas and new levels of stakeholder engagement. Carrot makes it easy for founders to engage with employees and investors, creating alignment for everyone.
-
-[Carrot](https://carrot.io/) is GitHub for the rest of your company.
-
-Transparency expectations are changing. Organizations need to change as well if they are going to attract and retain savvy employees and investors. Just as open source changed the way we build software, transparency changes how we build successful companies with information that is open, interactive, and always accessible. Carrot turns transparency into a competitive advantage.
+Transparency expectations are changing. Organizations need to change as well if they are going to attract and retain savvy teams. Just as open source changed the way we build software, transparency changes how we build successful companies with information that is open, interactive, and always accessible. **Carrot turns transparency into a competitive advantage**.
 
 To get started, head to: [Carrot](https://carrot.io/)
 

--- a/project.clj
+++ b/project.clj
@@ -38,10 +38,10 @@
     ;; NB: encore pulled in from oc.lib
     [com.taoensso/faraday "1.10.0-alpha1" :exclusions [com.amazonaws/aws-java-sdk-dynamodb joda-time com.taoensso/encore]]
     ;; Faraday dependency, not pulled in? https://hc.apache.org/
-    [org.apache.httpcomponents/httpclient "4.5.4"]
+    [org.apache.httpcomponents/httpclient "4.5.5"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.8"]
+    [open-company/lib "0.16.0"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -62,7 +62,7 @@
   ;; All profile plugins
   :plugins [
     ;; Common ring tasks https://github.com/weavejester/lein-ring
-    [lein-ring "0.12.2"]
+    [lein-ring "0.12.3"]
     ;; Get environment settings from different sources https://github.com/weavejester/environ
     [lein-environ "1.1.0"]
   ]
@@ -107,7 +107,7 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.5.0" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.1" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -20,11 +20,12 @@
                                                                       :access-key c/aws-access-key-id
                                                                       :secret-key c/aws-secret-access-key}}})))))
 
-(defn start []
+(defn- start⬆ []
   (alter-var-root #'system component/start))
 
 (defn stop []
-  (alter-var-root #'system (fn [s] (when s (component/stop s)))))
+  (alter-var-root #'system (fn [s] (when s (component/stop s))))
+  (println (str "When you're ready to start the system again, just type: (go)\n")))
 
 (defn go
   
@@ -32,7 +33,7 @@
   
   ([port]
   (init port)
-  (start)
+  (start⬆)
   (app/echo-config port)
   (println (str "Now serving changes from the REPL.\n"
                 "When you're ready to stop the system, just type: (stop)\n"))

--- a/src/oc/change/api/websockets.clj
+++ b/src/oc/change/api/websockets.clj
@@ -1,6 +1,6 @@
 (ns oc.change.api.websockets
   "WebSocket server handler."
-  (:require [clojure.core.async :as async :refer (>!! <!!)]
+  (:require [clojure.core.async :as async :refer (>!! <!)]
             [taoensso.sente :as sente]
             [taoensso.timbre :as timbre]
             [compojure.core :as compojure :refer (defroutes GET POST)]
@@ -139,7 +139,7 @@
   (timbre/info "Starting sender...")
   (async/go (while @sender-go
     (timbre/debug "Sender waiting...")
-    (let [message (<!! watcher/sender-chan)]
+    (let [message (<! watcher/sender-chan)]
       (timbre/debug "Processing message on sender channel...")
       (if (:stop message)
         (do (reset! sender-go false) (timbre/info "Sender stopped."))

--- a/src/oc/change/async/persistence.clj
+++ b/src/oc/change/async/persistence.clj
@@ -23,7 +23,7 @@
   "
   Handles 3 types of messages: status, seen, and change
 
-  NB: Uses 'blocking' core.async put `!!>`, not `parked` core.async put `!>` because even though this
+  NB: Uses 'blocking' core.async put `>!!`, not `parked` core.async put `>!` because even though this
   is called from inside a go block, it's also inside an `async/thread`.
   "
 

--- a/src/oc/change/async/persistence.clj
+++ b/src/oc/change/async/persistence.clj
@@ -4,7 +4,7 @@
 
   Use of this persistence is through core/async. A message is sent to the `persistence-chan`.
   "
-  (:require [clojure.core.async :as async :refer (>! >!! <!)]
+  (:require [clojure.core.async :as async :refer (>!! <!)]
             [defun.core :refer (defun-)]
             [taoensso.timbre :as timbre]
             [oc.change.resources.user :as u]
@@ -23,7 +23,8 @@
   "
   Handles 3 types of messages: status, seen, and change
 
-  NB: Uses 'parked' core.async put `!>` so must be called from inside a go block
+  NB: Uses 'blocking' core.async put `!!>`, not `parked` core.async put `!>` because even though this
+  is called from inside a go block, it's also inside an `async/thread`.
   "
 
   ([message :guard :status]
@@ -38,7 +39,7 @@
           status (map #(apply merge %) (vals (merge-with concat
                                                 (group-by :container-id seens)
                                                 (group-by :container-id changes))))]
-      (>! watcher/sender-chan {:event [:container/status status]
+      (>!! watcher/sender-chan {:event [:container/status status]
                                 :client-id client-id}))))
 
   ([message :guard :seen]

--- a/src/oc/change/components.clj
+++ b/src/oc/change/components.clj
@@ -11,16 +11,20 @@
   component/Lifecycle
 
   (start [component]
+    (timbre/info "[http] starting...")
     (let [handler (get-in component [:handler :handler] handler)
           server  (httpkit/run-server handler options)]
       (websockets-api/start)
+      (timbre/info "[http] started")
       (assoc component :http-kit server)))
 
   (stop [{:keys [http-kit] :as component}]
     (if http-kit
       (do
+        (timbre/info "[http] stopping...")
         (http-kit)
         (websockets-api/stop)
+        (timbre/info "[http] stopped")
         (dissoc component :http-kit))
       component)))
  
@@ -28,27 +32,30 @@
   component/Lifecycle
 
   (start [component]
-    (timbre/info "[handler] starting")
+    (timbre/info "[handler] started")
     (assoc component :handler (handler-fn component)))
 
   (stop [component]
+    (timbre/info "[handler] stopped")
     (dissoc component :handler)))
 
 (defrecord AsyncConsumers []
   component/Lifecycle
 
   (start [component]
-    (timbre/info "[async-consumers] starting")
+    (timbre/info "[async-consumers] starting...")
     (persistence/start) ; core.async channel consumer for persisting events
     (watcher/start) ; core.async channel consumer for watched items (containers watched by websockets) events
+    (timbre/info "[async-consumers] started")
     (assoc component :async-consumers true))
 
   (stop [{:keys [async-consumers] :as component}]
     (if async-consumers
       (do
-        (timbre/info "[async-consumers] stopping")
+        (timbre/info "[async-consumers] stopping...")
         (persistence/stop) ; core.async channel consumer for persisting events
         (watcher/stop) ; core.async channel consumer for watched items (containers watched by websockets) events
+        (timbre/info "[async-consumers] stopped")
         (dissoc component :async-consumers))
     component)))
 


### PR DESCRIPTION
No Trello card.

Just cleans up our use of the core.async producer/consumer pattern we have throughout many of the services with a parked, rather than a blocked read.

Also discourages use of `(start)` at the REPL and improves component life-cycle logging.

To test:

- [x] Review the codes
- [x] Fire up the REPL
- [x] `(go) (stop) (go)` sequence. All components start propertly, stop properly, start properly?
- [x] Start service up with `lein start`, just as good as REPL's `(go)`?
- [x] With 2 users, have one create some new content, create new boards, nav. around, SQS messages about new content consumed OK? new content message sent OK? board seen messages persisted OK? Brilliant.
- [x] Merge
- [x] Deploy
- [ ] Win a hod dog eating contest