### PR TITLE
Don't skip draft messages. 

### DIFF
--- a/src/oc/change/api/websockets.clj
+++ b/src/oc/change/api/websockets.clj
@@ -96,7 +96,8 @@
   [{:as ev-msg :keys [event id ?data ring-req ?reply-fn send-fn]}]
   (let [user-id (-> ring-req :params :user-id)
         client-id (-> ring-req :params :client-id)
-        container-ids ?data]
+        data-ids ?data
+        container-ids (replace {c/draft-board-uuid (str c/draft-board-uuid "-" user-id)} data-ids)]
     (timbre/info "[websocket] container/watch for:" container-ids "by:" user-id "/" client-id)
     (>!! persistence/persistence-chan {:status true
                                        :container-ids container-ids

--- a/src/oc/change/app.clj
+++ b/src/oc/change/app.clj
@@ -60,19 +60,17 @@
         error (if (:test-error msg-body) (/ 1 0) false) ; a message testing Sentry error reporting
         change-type (keyword (:notification-type msg-body))
         resource-type (keyword (:resource-type msg-body))
-        container-id (or (-> msg-body :board :uuid) ; entry or board
-                         (-> msg-body :org :uuid)) ; org
+        container-id  (if (= "draft" (-> msg-body :content :new :status))
+                        draft-board-uuid
+                        (or (-> msg-body :board :uuid) ; entry or board
+                            (-> msg-body :org :uuid))) ; org
         item-id (or (-> msg-body :content :new :uuid) ; new or update
                     (-> msg-body :content :old :uuid)) ; delete
         change-at (or (-> msg-body :content :new :updated-at) ; add / update
                       (:notification-at msg-body)) ; delete
-        draft? (or (= container-id draft-board-uuid)
-                   (= "draft" (or (-> msg-body :content :new :status)
-                              (and (= change-type "delete") (-> msg-body :content :old :status)))))
         user-id (-> msg-body :user :user-id)]
     (timbre/info "Received message from SQS:" msg-body)
     (if (and
-          (not draft?)
           (or (= change-type :add) (= change-type :update) (= change-type :delete))
           (or (= resource-type :entry) (= resource-type :board)))
       
@@ -97,15 +95,11 @@
                                              :user-id user-id
                                              :change-at change-at}}))
       
-      ;; Org draft or unknown
+      ;; Org or unknown
       (cond
         (= resource-type :org)
         (timbre/warn "Unhandled org message from SQS:" change-type resource-type)
- 
-        draft?
-        (timbre/info "Skipping draft message from SQS:" change-type resource-type)
-
-        :else
+        :default
         (timbre/warn "Unknown message from SQS:" change-type resource-type))))
   (sqs/ack done-channel msg))
 

--- a/src/oc/change/config.clj
+++ b/src/oc/change/config.clj
@@ -51,6 +51,6 @@
 (defonce aws-sqs-change-queue (env :aws-sqs-change-queue))
 
 ;; ----- Change Service -----
-
+(defonce draft-board-uuid "0000-0000-0000")
 (defonce change-ttl (or (env :oc-change-ttl) 30)) ; days
 (defonce seen-ttl (or (env :oc-seen-ttl) 30)) ; days


### PR DESCRIPTION
This change doesn't ignore the draft messages from the storage service. Instead it ensures the container id has the draft board id `000...`. 

To test
- open up a window and login 
- open up an incognito window and login with the same user
- create a draft as user 1
- [x] does it show up for user 2
- [x] does the draft count increment?
- edit the draft as user 1
- [x] do the changes show up for user 2?
- delete the draft as user 1
- [x] does the draft get deleted for user 2?

