### PR TITLE
Fix change ttl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     [org.apache.httpcomponents/httpclient "4.5.6"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.14"]
+    [open-company/lib "0.16.26alpha"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -51,7 +51,6 @@
     ;; Schema - Data validation https://github.com/Prismatic/schema
     ;; Timbre - Pure Clojure/Script logging library https://github.com/ptaoussanis/timbre
     ;; Amazonica - A comprehensive Clojure client for the AWS API https://github.com/mcohen01/amazonica
-    ;; Faraday DynamoDB client https://github.com/ptaoussanis/faraday
     ;; Raven - Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     ;; Cheshire - JSON encoding / decoding https://github.com/dakrone/cheshire
     ;; clj-time - Date and time lib https://github.com/clj-time/clj-time

--- a/project.clj
+++ b/project.clj
@@ -188,7 +188,9 @@
 
     ;; Exclude testing namespaces
     :tests-paths ["test"]
-    :exclude-namespaces [:test-paths]
+
+    ;; Exclude utility namespace since it's not used directly from the service app
+    :exclude-namespaces [:test-paths oc.change.util.fix-ttl]
   }
 
   :zprint {:old? false}

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     [org.apache.httpcomponents/httpclient "4.5.6"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.26alpha"]
+    [open-company/lib "0.16.26"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/src/oc/change/db/migrations/1543930445186_update_ttl.edn
+++ b/src/oc/change/db/migrations/1543930445186_update_ttl.edn
@@ -20,11 +20,11 @@
 ;; NB: The fact that these migrations have been run already does not currently persist, so the up method
 ;; need to be idempotent
 (defn up [dynamodb-opts]
+  (when-not (clojure.string/starts-with? (:endpoint dynamodb-opts) "http://localhost")
+    ;; Add ttl to change table
+    (maybe-enable-ttl dynamodb-opts change/table-name)
 
-  ;; Add ttl to change table
-  (maybe-enable-ttl dynamodb-opts change/table-name)
-
-  ;; Add ttl to seen table
-  (maybe-enable-ttl dynamodb-opts seen/table-name)
+    ;; Add ttl to seen table
+    (maybe-enable-ttl dynamodb-opts seen/table-name))
 
   true) ; return true on success

--- a/src/oc/change/db/migrations/1543930445186_update_ttl.edn
+++ b/src/oc/change/db/migrations/1543930445186_update_ttl.edn
@@ -5,24 +5,26 @@
             [oc.change.resources.change :as change]
             [oc.change.resources.seen :as seen]))
 
+(defn maybe-enable-ttl [dynamodb-opts table-name]
+  (let [ttl-desciption (describe-time-to-live dynamodb-opts :table-name table-name)]
+    (if (not= (-> ttl-desciption :time-to-live-description :time-to-live-status) "ENABLED")
+      (do
+        (println "Enabling TTL on " table-name)
+        (println
+          (update-time-to-live
+            dynamodb-opts
+            :table-name table-name
+            :time-to-live-specification {:attribute-name "ttl" :enabled true})))
+      (println "TTL already enabled on " table-name))))
+
 ;; NB: The fact that these migrations have been run already does not currently persist, so the up method
 ;; need to be idempotent
 (defn up [dynamodb-opts]
 
-  (println "opts" dynamodb-opts)
-
   ;; Add ttl to change table
-  (println
-    (update-time-to-live
-      dynamodb-opts
-      :table-name change/table-name
-      :time-to-live-specification {:attribute-name "ttl" :enabled true}))
+  (maybe-enable-ttl dynamodb-opts change/table-name)
 
   ;; Add ttl to seen table
-  (println
-    (update-time-to-live
-      dynamodb-opts
-      :table-name seen/table-name
-      :time-to-live-specification {:attribute-name "ttl" :enabled true}))
+  (maybe-enable-ttl dynamodb-opts seen/table-name)
 
   true) ; return true on success

--- a/src/oc/change/db/migrations/1543930445186_update_ttl.edn
+++ b/src/oc/change/db/migrations/1543930445186_update_ttl.edn
@@ -1,0 +1,28 @@
+(ns oc.change.db.migrations.update-ttl
+  (:use [amazonica.aws.dynamodbv2])
+  (:require [oc.lib.db.migrations :as m]
+            [oc.change.config :as config]
+            [oc.change.resources.change :as change]
+            [oc.change.resources.seen :as seen]))
+
+;; NB: The fact that these migrations have been run already does not currently persist, so the up method
+;; need to be idempotent
+(defn up [dynamodb-opts]
+
+  (println "opts" dynamodb-opts)
+
+  ;; Add ttl to change table
+  (println
+    (update-time-to-live
+      dynamodb-opts
+      :table-name change/table-name
+      :time-to-live-specification {:attribute-name "ttl" :enabled true}))
+
+  ;; Add ttl to seen table
+  (println
+    (update-time-to-live
+      dynamodb-opts
+      :table-name seen/table-name
+      :time-to-live-specification {:attribute-name "ttl" :enabled true}))
+
+  true) ; return true on success

--- a/src/oc/change/resources/change.clj
+++ b/src/oc/change/resources/change.clj
@@ -26,7 +26,11 @@
 
 (schema/defn ^:always-validate store!
   [container-id :- UniqueDraftID item-id :- UniqueDraftID change-at :- lib-schema/ISO8601]
-  (let [ttl-date (time/plus (time/now) (time/days c/change-ttl))]
+  (let [;; If ttl value is set from env var it's a string, if it's default is an int
+        fixed-change-ttl (if (string? c/change-ttl)
+                           (Integer. (re-find #"\d+" c/change-ttl))
+                           c/change-ttl)
+        ttl-date (time/plus (time/now) (time/days fixed-change-ttl))]
     (far/put-item c/dynamodb-opts table-name {
         :container_id container-id
         :item_id item-id

--- a/src/oc/change/resources/change.clj
+++ b/src/oc/change/resources/change.clj
@@ -26,11 +26,12 @@
 
 (schema/defn ^:always-validate store!
   [container-id :- UniqueDraftID item-id :- UniqueDraftID change-at :- lib-schema/ISO8601]
-  (far/put-item c/dynamodb-opts table-name {
-      :container_id container-id
-      :item_id item-id
-      :change_at change-at
-      :ttl (coerce/to-epoch (time/plus (time/now) (time/days c/change-ttl)))})
+  (let [ttl-date (time/plus (time/now) (time/days c/change-ttl))]
+    (far/put-item c/dynamodb-opts table-name {
+        :container_id container-id
+        :item_id item-id
+        :change_at change-at
+        :ttl (coerce/to-epoch ttl-date)}))
   true)
 
 (schema/defn ^:always-validate retrieve :- [{:container-id UniqueDraftID :item-id UniqueDraftID :change-at lib-schema/ISO8601}]

--- a/src/oc/change/resources/change.clj
+++ b/src/oc/change/resources/change.clj
@@ -30,7 +30,7 @@
       :container_id container-id
       :item_id item-id
       :change_at change-at
-      :ttl (coerce/to-epoch (time/plus (time/now) (time/minutes c/change-ttl)))})
+      :ttl (coerce/to-epoch (time/plus (time/now) (time/days c/change-ttl)))})
   true)
 
 (schema/defn ^:always-validate retrieve :- [{:container-id UniqueDraftID :item-id UniqueDraftID :change-at lib-schema/ISO8601}]

--- a/src/oc/change/resources/change.clj
+++ b/src/oc/change/resources/change.clj
@@ -30,7 +30,7 @@
       :container_id container-id
       :item_id item-id
       :change_at change-at
-      :ttl (coerce/to-long (time/plus (time/now) (time/days c/change-ttl)))})
+      :ttl (coerce/to-epoch (time/plus (time/now) (time/minutes c/change-ttl)))})
   true)
 
 (schema/defn ^:always-validate retrieve :- [{:container-id UniqueDraftID :item-id UniqueDraftID :change-at lib-schema/ISO8601}]

--- a/src/oc/change/resources/seen.clj
+++ b/src/oc/change/resources/seen.clj
@@ -2,7 +2,6 @@
   "Store tuples of: user-id, container-id, item-id and timestamp, with a TTL"
   (:require [taoensso.faraday :as far]
             [schema.core :as schema]
-            [taoensso.timbre :as timbre]
             [clj-time.core :as time]
             [clj-time.coerce :as coerce]
             [oc.lib.schema :as lib-schema]

--- a/src/oc/change/resources/seen.clj
+++ b/src/oc/change/resources/seen.clj
@@ -25,14 +25,15 @@
     container-id :- lib-schema/UniqueID
     item-id :- lib-schema/UniqueID
     seen-at :- lib-schema/ISO8601]
-  (far/put-item c/dynamodb-opts table-name {
-      :user_id user-id
-      :container_item_id (str container-id "-" item-id)
-      :container_id container-id
-      :item-id item-id
-      :user-id user-id
-      :seen_at seen-at
-      :ttl (coerce/to-epoch (time/plus (time/now) (time/days c/seen-ttl)))})
+  (let [ttl-date (time/plus (time/now) (time/days c/seen-ttl))]
+    (far/put-item c/dynamodb-opts table-name {
+        :user_id user-id
+        :container_item_id (str container-id "-" item-id)
+        :container_id container-id
+        :item-id item-id
+        :user-id user-id
+        :seen_at seen-at
+        :ttl (coerce/to-epoch ttl-date)}))
   true))
 
 (schema/defn ^:always-validate retrieve :- [{:container-id lib-schema/UniqueID :item-id lib-schema/UniqueID :seen-at lib-schema/ISO8601}]

--- a/src/oc/change/resources/seen.clj
+++ b/src/oc/change/resources/seen.clj
@@ -24,7 +24,11 @@
     container-id :- lib-schema/UniqueID
     item-id :- lib-schema/UniqueID
     seen-at :- lib-schema/ISO8601]
-  (let [ttl-date (time/plus (time/now) (time/days c/seen-ttl))]
+  (let [;; If ttl value is set from env var it's a string, if it's default is an int
+        fixed-seen-ttl (if (string? c/seen-ttl)
+                         (Integer. (re-find #"\d+" c/seen-ttl))
+                         c/seen-ttl)
+        ttl-date (time/plus (time/now) (time/days fixed-seen-ttl))]
     (far/put-item c/dynamodb-opts table-name {
         :user_id user-id
         :container_item_id (str container-id "-" item-id)

--- a/src/oc/change/resources/seen.clj
+++ b/src/oc/change/resources/seen.clj
@@ -31,7 +31,7 @@
       :item-id item-id
       :user-id user-id
       :seen_at seen-at
-      :ttl (coerce/to-long (time/plus (time/now) (time/days c/seen-ttl)))})
+      :ttl (coerce/to-epoch (time/plus (time/now) (time/minutes c/seen-ttl)))})
   true))
 
 (schema/defn ^:always-validate retrieve :- [{:container-id lib-schema/UniqueID :item-id lib-schema/UniqueID :seen-at lib-schema/ISO8601}]

--- a/src/oc/change/resources/seen.clj
+++ b/src/oc/change/resources/seen.clj
@@ -31,7 +31,7 @@
       :item-id item-id
       :user-id user-id
       :seen_at seen-at
-      :ttl (coerce/to-epoch (time/plus (time/now) (time/minutes c/seen-ttl)))})
+      :ttl (coerce/to-epoch (time/plus (time/now) (time/days c/seen-ttl)))})
   true))
 
 (schema/defn ^:always-validate retrieve :- [{:container-id lib-schema/UniqueID :item-id lib-schema/UniqueID :seen-at lib-schema/ISO8601}]

--- a/src/oc/change/util/fix_ttl.clj
+++ b/src/oc/change/util/fix_ttl.clj
@@ -1,0 +1,35 @@
+(ns oc.change.util.fix-ttl
+  (:require [taoensso.faraday :as far]
+            [clj-time.coerce :as coerce]
+            [oc.lib.db.migrations :as m]
+            [oc.change.config :as config]
+            [oc.change.resources.change :as change]
+            [oc.change.resources.seen :as seen]))
+
+(defn fix-change-ttl []
+  (println "Scanning " change/table-name)
+  (let [results (far/scan config/dynamodb-opts change/table-name {:attr-conds {:ttl [:gt 9999999999]}})]
+    (for [r results]
+      (let [fixed-ttl (coerce/to-epoch (coerce/from-long (long (:ttl r))))]
+        (println "   Fixing:" (:ttl r) "->" fixed-ttl)
+        (far/update-item config/dynamodb-opts change/table-name
+         {:container_id (:container_id r)
+          :item_id (:item_id r)}
+         {:update-expr "SET #k = :v"
+          :expr-attr-names {"#k" "ttl"}
+          :expr-attr-vals  {":v" fixed-ttl}
+          :return :all-new})))))
+
+(defn fix-seen-ttl []
+  (println "Scanning " seen/table-name)
+  (let [results (far/scan config/dynamodb-opts seen/table-name {:attr-conds {:ttl [:gt 9999999999]}})]
+    (for [r results]
+      (let [fixed-ttl (coerce/to-epoch (coerce/from-long (long (:ttl r))))]
+        (println "   Fixing:" (:ttl r) "->" fixed-ttl)
+        (far/update-item config/dynamodb-opts seen/table-name
+         {:user_id (:user_id r)
+          :container_item_id (:container_item_id r)}
+         {:update-expr "SET #k = :v"
+          :expr-attr-names {"#k" "ttl"}
+          :expr-attr-vals  {":v" fixed-ttl}
+          :return :all-new})))))

--- a/src/oc/change/util/ttl.clj
+++ b/src/oc/change/util/ttl.clj
@@ -1,0 +1,19 @@
+(ns oc.change.util.ttl
+  (:require [clj-time.core :as time]
+            [clj-time.coerce :as coerce]))
+
+(defn ttl-epoch
+  "Given a ttl value, make sure it's an integer to avoid errors, and return the epoch
+   of now plus the ttl in days."
+  [ttl]
+  (let [;; If ttl value is set from env var it's a string, if it's default is an int
+        fixed-change-ttl (if (string? ttl)
+                           (Integer. (re-find #"\d+" ttl))
+                           ttl)
+        ttl-date (time/plus (time/now) (time/days fixed-change-ttl))]
+    (coerce/to-epoch ttl-date)))
+
+(defn ttl-now
+  "Return the current time in epoch."
+  []
+  (coerce/to-epoch (time/now)))


### PR DESCRIPTION
Card: https://trello.com/c/9kQLSfxE

Review with: https://github.com/open-company/open-company-lib/pull/44

Found out that we were setting ttl with epoch milliseconds instead of seconds (like DynamoDB reads them). Also were are not setting the ttl attribute, this means the records are never removed, this leads to unexpected results (can be that the bolding issue we were seeing is caused by this).

This fix is composed of these things:
- use `to-epoch` instead of `to-long` to set the ttl
- filter out expired rows when we query for seen and change records (dynamodb can take up to 48 hours to remove them, this can lead to bugs)
- set the TTL attribute with a migration (this way when we setup new instances we don't need to remember to set it manually)
- run a script that loads all the milliseconds ttl (greater than 9999999999) and replace it with the seconds epoch

To test:
- run `lein migrate-db` locally
- [x] everything good, no errors? Good
- [x] check the code of `oc.change.util.fix-ttl`
- open a local repl
- [x] run `oc.change.util.fix-ttl/fix-change-ttl` function locally
- [x] run `oc.change.util.fix-ttl/fix-seen-ttl` function locally
- run change service locally
- [x] everything good, no errors? Good
- [x] make sure new items are marked as new (new label and bold section)
- [x] make sure new items are not marked as new when you have seen them
- update the release version of lib to drop the alpha in both lib and change
- release the lib to clojars
- merge both PRs
- deploy