### PR TITLE
Post sorting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.1-RC1"]
+    [org.clojure/clojure "1.10.1"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
     [org.clojure/tools.cli "0.4.2"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -38,10 +38,10 @@
     ;; NB: encore pulled in from oc.lib
     [com.taoensso/faraday "1.10.0-alpha1" :exclusions [com.amazonaws/aws-java-sdk-dynamodb joda-time com.taoensso/encore]]
     ;; Faraday dependency, not pulled in? https://hc.apache.org/
-    [org.apache.httpcomponents/httpclient "4.5.8"]
+    [org.apache.httpcomponents/httpclient "4.5.9"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.11"]
+    [open-company/lib "0.17.12"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -81,7 +81,7 @@
         ;; NB: commons-codec pulled in by oc.lib
         [midje "1.9.8" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]]
         ;; Clojure WebSocket client https://github.com/cch1/http.async.client
-        [http.async.client "1.3.0"]
+        [http.async.client "1.3.1"]
         ;; Test Ring requests https://github.com/weavejester/ring-mock
         [ring-mock "0.1.5"]
       ]

--- a/src/oc/change/api/websockets.clj
+++ b/src/oc/change/api/websockets.clj
@@ -171,7 +171,7 @@
         client-id (-> ring-req :params :client-id)
         item-ids ?data]
     (timbre/info "[websocket] item/who-read-count for:" item-ids)
-    (>!! persistence/persistence-chan {:who-read-count true :item-ids item-ids :client-id client-id})))
+    (>!! persistence/persistence-chan {:who-read-count true :item-ids item-ids :client-id client-id :user-id user-id})))
 
 ;; ----- Sente router event loop (incoming from Sente/WebSocket) -----
 

--- a/src/oc/change/async/persistence.clj
+++ b/src/oc/change/async/persistence.clj
@@ -148,9 +148,10 @@
   ;; Lookup how many reads are there for each of a sequence of specified items
   ;; Send the result to the sender's channel as an item/counts message
   (let [item-ids (:item-ids message)
-        client-id (:client-id message)]
-    (timbre/info "Who read cound request for:" item-ids "by:" client-id)
-    (let [reads (read/counts item-ids)]
+        client-id (:client-id message)
+        user-id (:user-id message)]
+    (timbre/info "Who read cound request for:" item-ids "by:" client-id "for:" user-id)
+    (let [reads (read/counts item-ids user-id)]
       (>!! watcher/sender-chan {:event [:item/counts reads]
                                 :client-id client-id}))))
 

--- a/src/oc/change/config.clj
+++ b/src/oc/change/config.clj
@@ -54,7 +54,7 @@
 ;; ----- Change service -----
 
 (defonce draft-board-uuid "0000-0000-0000")
-(defonce change-ttl (or (env :oc-change-ttl) 30)) ; days
-(defonce seen-ttl (or (env :oc-seen-ttl) 30)) ; days
+(defonce change-ttl (or (env :oc-change-ttl) (* 30 6))) ; 6 months
+(defonce seen-ttl (or (env :oc-seen-ttl) (* 30 6))) ; days
 
 (defonce passphrase (env :open-company-auth-passphrase))

--- a/src/oc/change/resources/read.clj
+++ b/src/oc/change/resources/read.clj
@@ -68,7 +68,7 @@
 
 (schema/defn ^:always-validate counts :- [{:item-id lib-schema/UniqueID
                                            :count schema/Int
-                                           :last-read-at lib-schema/ISO8601}]
+                                           :last-read-at (schema/maybe lib-schema/ISO8601)}]
   [item-ids :- [lib-schema/UniqueID] user-id :- lib-schema/UniqueID]
   (pmap (partial count-for user-id) item-ids))
 

--- a/src/oc/change/resources/read.clj
+++ b/src/oc/change/resources/read.clj
@@ -10,7 +10,6 @@
 
 ;; In theory, DynamoDB (and by extension, Faraday) support `{:return :count}` but it doesn't seem to be working
 ;; https://github.com/ptaoussanis/faraday/issues/91
-;; `{return [:none]}` is simply a way to get an empty map for every item, then we count the empty maps
 (defn- count-for [user-id item-id]
   (let [results (far/query c/dynamodb-opts table-name {:item_id [:eq item-id]})]
     {:item-id item-id :count (count results) :last-read-at (:read_at (last (sort-by :read-at (filterv #(= (:user_id %) user-id) results))))}))

--- a/src/oc/change/resources/read.clj
+++ b/src/oc/change/resources/read.clj
@@ -11,9 +11,9 @@
 ;; In theory, DynamoDB (and by extension, Faraday) support `{:return :count}` but it doesn't seem to be working
 ;; https://github.com/ptaoussanis/faraday/issues/91
 ;; `{return [:none]}` is simply a way to get an empty map for every item, then we count the empty maps
-(defn- count-for [item-id]
-  (let [results (far/query c/dynamodb-opts table-name {:item_id [:eq item-id]} {:return [:none]})]
-    {:item-id item-id :count (count results)}))
+(defn- count-for [user-id item-id]
+  (let [results (far/query c/dynamodb-opts table-name {:item_id [:eq item-id]})]
+    {:item-id item-id :count (count results) :last-read-at (:read_at (last (sort-by :read-at (filterv #(= (:user_id %) user-id) results))))}))
 
 (schema/defn ^:always-validate store!
 
@@ -67,9 +67,10 @@
 
 
 (schema/defn ^:always-validate counts :- [{:item-id lib-schema/UniqueID
-                                           :count schema/Int}]
-  [item-ids :- [lib-schema/UniqueID]]
-  (pmap count-for item-ids))
+                                           :count schema/Int
+                                           :last-read-at lib-schema/ISO8601}]
+  [item-ids :- [lib-schema/UniqueID] user-id :- lib-schema/UniqueID]
+  (pmap (partial count-for user-id) item-ids))
 
 (comment
 
@@ -115,7 +116,7 @@
   (read/store! "1111-1111-1111" "cccc-cccc-cccc" "eeee-eeee-eee1" "aaaa-aaaa-aaaa"
                "Albert Camus" "http//..." (oc-time/current-timestamp))
 
-  (read/counts ["eeee-eeee-eeee" "eeee-eeee-eee1"])
+  (read/counts ["eeee-eeee-eeee" "eeee-eeee-eee1"] "1234-1234-1234")
 
   (far/delete-table c/dynamodb-opts read/table-name)
 )


### PR DESCRIPTION
Review with: https://github.com/open-company/open-company-web/pull/911

This introduce a change in the `:who-read-count` response but it should backward compatible since it only adds a new parameter called `last-read-at` populated with the last read on that item by the requesting user. It's used later by the client to check if there were new comments added from that moment.